### PR TITLE
Async State Subscriptions

### DIFF
--- a/myosin/exceptions/state.py
+++ b/myosin/exceptions/state.py
@@ -11,6 +11,11 @@ class StateException(Exception):
         self.message = msg
 
 
+class UninitializedStateError(StateException):
+    def __init__(self, msg: str = "") -> None:
+        super().__init__(msg)
+
+
 class HashNotFound(StateException):
     def __init__(self, msg: str = "The input model has an unexpected typehash") -> None:
         super().__init__(msg=msg)

--- a/myosin/exceptions/state.py
+++ b/myosin/exceptions/state.py
@@ -11,6 +11,11 @@ class StateException(Exception):
         self.message = msg
 
 
+class HashNotFound(StateException):
+    def __init__(self, msg: str = "The input model has an unexpected typehash") -> None:
+        super().__init__(msg=msg)
+
+
 class NullCheckoutError(StateException):
     def __init__(self, msg: str = "The requested model does not exist in state registry") -> None:
         super().__init__(msg=msg)

--- a/myosin/models/base.py
+++ b/myosin/models/base.py
@@ -22,6 +22,9 @@ class BaseModel(ABC):
     def __typehash__(self) -> int:
         return hash(type(self))
 
+    def __hash__(self) -> int:
+        return super().__hash__()
+
     def __eq__(self, o: object) -> bool:
         if hasattr(o, 'id') and hasattr(self, 'id'):
             return o.id == self.id  # type: ignore

--- a/myosin/state/ssm.py
+++ b/myosin/state/ssm.py
@@ -56,7 +56,7 @@ class SSM(Generic[_S]):
         self._logger.debug("%s Subscriber operations: %s", type(self.ref).__name__, operations)
         # filter by operations which yielded an exception
         exceptions: List[Tuple[str, Exception]] = list(
-            filter(lambda x: x[1] is not None, operations))
+            filter(lambda x: type(x[1]) is BaseException, operations))
         for func, exc in exceptions:
             self._logger.exception("Subscriber function: %s encountered an exception: %s", func,
                                    "".join(traceback.format_exception(

--- a/myosin/state/ssm.py
+++ b/myosin/state/ssm.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+import logging
+import asyncio
+import traceback
+from typing import Generic, List, Tuple, TypeVar, Callable
+
+from myosin.models.state import StateModel
+from myosin.typing import AsyncCallback
+
+
+_S = TypeVar('_S', bound=StateModel)
+
+
+class SSM(Generic[_S]):
+
+    def __init__(self, reference: _S) -> None:
+        self._logger = logging.getLogger(__name__)
+        self.ref = reference
+        self.queue = []
+
+    @property
+    def refhash(self) -> int:
+        return hash(self.__ref)
+
+    @property
+    def typehash(self) -> int:
+        return self.ref.__typehash__()
+
+    @property
+    def ref(self) -> _S:
+        return self.__ref
+
+    @ref.setter
+    def ref(self, model: _S) -> None:
+        self.__ref = model
+
+    @property
+    def queue(self) -> List[Callable[[_S], AsyncCallback]]:
+        return self.__queue
+
+    @queue.setter
+    def queue(self, queue: List[Callable[[_S], AsyncCallback]]) -> None:
+        self.__queue = queue
+
+    async def execute(self) -> None:
+        """
+        Executes all subscriber coroutines with new model reference.
+        """
+        # construct coroutine lists
+        tasks = [callback(self.ref) for callback in self.queue]
+        # return results from coroutines with exceptions if any
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        # reformat tasks to display only the name
+        operations = tuple(zip(map(lambda x: x.__qualname__, tasks), results))
+        self._logger.debug("%s Subscriber operations: %s", type(self.ref).__name__, operations)
+        # filter by operations which yielded an exception
+        exceptions: List[Tuple[str, Exception]] = list(
+            filter(lambda x: x[1] is not None, operations))
+        for func, exc in exceptions:
+            self._logger.exception("Subscriber function: %s encountered an exception: %s", func,
+                                   "".join(traceback.format_exception(
+                                       etype=type(exc), value=exc, tb=exc.__traceback__
+                                   )))

--- a/myosin/state/state.py
+++ b/myosin/state/state.py
@@ -76,6 +76,17 @@ class State:
 
     @tutils.lock(tutils.state_lock)
     def commit(self, state: _T, cache: bool = False) -> _T:
+        """
+        Commit new state to system state and update state subscriber callbacks
+
+        :param state: modified copy of state
+        :type state: _T
+        :param cache: cache the state to disk once updated, defaults to False
+        :type cache: bool, optional
+        :raises HashNotFound: if system state has no state registered of the requested type 
+        :return: updated system state reference
+        :rtype: _T
+        """
         # automatic type inference by typehash
         _type_hash = hash(type(state))
         # verify typehash

--- a/myosin/state/state.py
+++ b/myosin/state/state.py
@@ -15,14 +15,16 @@ from monitor.models.experiment import Experiment
 from monitor.models.imaging_profile import ImagingProfile
 ```
 """
+import asyncio
 import copy
 import logging
-import asyncio
-import traceback
-from typing import Any, Coroutine, Dict, Tuple, Type, TypeVar, Callable, List
+from typing import Dict, Type, TypeVar, Callable
+
+from myosin.state.ssm import SSM
+from myosin.typing import AsyncCallback
 from myosin.utils.funcs import pformat
 from myosin.models.state import StateModel
-from myosin.exceptions.state import NullCheckoutError
+from myosin.exceptions.state import HashNotFound, NullCheckoutError
 from myosin.utils.concurrency import ThreadUtils as tutils
 
 # generic runtime model type
@@ -32,7 +34,7 @@ _T = TypeVar('_T', bound=StateModel)
 class State:
 
     # storage mechanism is { name: Model }
-    _ssm: Dict[int, Any] = {}
+    _ssm: Dict[int, SSM] = {}
 
     def __init__(self) -> None:
         self._logger = logging.getLogger(__name__)
@@ -49,67 +51,57 @@ class State:
         :param model: state model
         :type model: StateModel
         """
-        self._ssm[model.__typehash__()] = model
+        self._ssm[model.__typehash__()] = SSM[_T](model)
         self._logger.info("Loaded state model: %s", pformat(model.serialize()))
         return model
 
     @tutils.lock(tutils.state_lock)
-    def checkout(self, _type: Type[_T]) -> _T:
+    def checkout(self, state_type: Type[_T]) -> _T:
         """
-        Returns requested state model
+        Returns reference of requested state model
 
+        :param state_type: requested state model reference 
+        :type state_type: Type[_T]
+        :raises NullCheckoutError: if the requested state type does not exist 
         :return: deep copy of requested state model
-        :rtype: StateModel
+        :rtype: _T
         """
-        self._logger.info("Checking out state model of type %s", _type)
-        _type_hash = hash(_type)
+        self._logger.info("Checking out state model of type %s", state_type)
+        _type_hash = hash(state_type)
         self._logger.debug("Computed type hash: %s", _type_hash)
-        mdl = self._ssm.get(_type_hash)
-        if not mdl:
+        ssm = self._ssm.get(_type_hash)
+        if not ssm:
             raise NullCheckoutError
-        return copy.deepcopy(mdl)
+        return copy.deepcopy(ssm.ref)
 
     @tutils.lock(tutils.state_lock)
     def commit(self, state: _T, cache: bool = False) -> _T:
+        # automatic type inference by typehash
         _type_hash = hash(type(state))
-        self._ssm[_type_hash] = state
+        # verify typehash
+        ssm = self._ssm.get(_type_hash)
+        if not ssm:
+            self._logger.error("Committed typehash: %s did not match any state model", _type_hash)
+            raise HashNotFound
+        ssm.ref = state
+        asyncio.run(ssm.execute())
         if cache:
             state.cache()
             self._logger.debug("Cached commited state model %s", state)
         return state
 
-    def subscribe(self, state_type: Type[_T], callback: Callable[[_T], Coroutine[Any, Any, None]]) -> None:
+    def subscribe(self, state_type: Type[_T], callback: Callable[[_T], AsyncCallback]) -> None:
         """
         Subscribe an asynchronous state change listener to a designated runtime model
 
-        :param state_type: runtime type to subscribe to
+        :param state_type: model type to subscribe to
         :type state_type: Type[T]
         :param callback: state change listener callback
-        :type callback: Callable[[T], Coroutine[Any, Any, None]]
+        :type callback: Callable[[T], AsyncCallback]
         """
-
-    async def _subscriber_runner(self, state_var: _T,
-                                 registry: List[Callable[[_T], Coroutine[Any, Any, None]]]) -> None:
-        """
-        Async runner that executes all subscriber coroutines with new runtime model state changes.
-
-        :param state_var: pre-validated runtime model to pass to subscribers
-        :type state_var: T
-        :param registry: list of subscriber coroutines
-        :type registry: List[Callable[[T], Awaitable[None]]]
-        """
-        # construct coroutine lists
-        tasks = [subscriber(state_var) for subscriber in registry]
-        # return results from coroutines with exceptions if any
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-        # reformat tasks to display only the name
-        operations = tuple(zip(map(lambda x: x.__qualname__, tasks), results))
-        self._logger.debug("%s Subscriber operations: %s", type(state_var).__name__, operations)
-        # filter by operations which yielded an exception
-        exceptions: List[Tuple[str, Exception]] = list(
-            filter(lambda x: x[1] is not None, operations))
-        for func, exc in exceptions:
-            self._logger.exception("Subscriber function: %s encountered an exception: %s", func,
-                                   "".join(traceback.format_exception(
-                                       etype=type(exc), value=exc, tb=exc.__traceback__
-                                   )))
+        _type_hash = hash(state_type)
+        ssm = self._ssm.get(_type_hash)
+        if not ssm:
+            self._logger.error("Subscribed typehash: %s did not match any state model", _type_hash)
+            raise HashNotFound
+        ssm.queue.append(callback)

--- a/myosin/typing/__init__.py
+++ b/myosin/typing/__init__.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
-from typing import Union
+from typing import Any, Coroutine, Union
+
 
 __all__ = [
     "_PKey"
 ]
 
 _PKey = Union[int, str]
+AsyncCallback = Coroutine[Any, Any, None]

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -86,7 +86,7 @@ class Runner:
 
     def run(self):
         while True:
-            time.sleep(1)
+            time.sleep(0.001)
             print(f"This is my username: {self.username}")
 
 
@@ -132,7 +132,7 @@ if __name__ == "__main__":
     _runner = Runner()
     Thread(target=_runner.run, args=(), daemon=True).start()
     while True:
-        time.sleep(1)
+        time.sleep(0.001)
         with State() as state:
             usr = state.checkout(User)
             usr.name = str(uuid.uuid4())

--- a/tests/integration/producer.py
+++ b/tests/integration/producer.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+import time
+import random
+
+from myosin import State
+
+
+class Point:
+
+    @property
+    def tc(self) -> float:
+        return random.uniform(0, 40)
+
+    @property
+    def timestamp(self) -> float:
+        return datetime.now().timestamp()
+
+
+class Producer:
+
+    def __init__(self) -> None:
+        with State() as state:
+            pass
+
+    def run(self, rate: int) -> None:
+        delay = 1 / rate
+        while True:
+            Point()
+            time.sleep(delay)

--- a/tests/resources/models.py
+++ b/tests/resources/models.py
@@ -9,7 +9,7 @@ SERIALIZED_MODEL = {
 }
 
 
-class TestState(StateModel):
+class DemoState(StateModel):
 
     def __init__(self, _id) -> None:
         super().__init__(_id)

--- a/tests/resources/models.py
+++ b/tests/resources/models.py
@@ -1,6 +1,33 @@
+from myosin import StateModel
+from typing import Any, Dict
+
 
 SERIALIZED_MODEL = {
     'id': 1,
     'name': "cS",
     'email': "chris@email.com"
 }
+
+
+class TestState(StateModel):
+
+    def __init__(self, _id) -> None:
+        super().__init__(_id)
+
+    @property
+    def name(self) -> str:
+        return self.__name
+
+    @name.setter
+    def name(self, name: str) -> None:
+        self.__name = name
+
+    def serialize(self) -> Dict[str, Any]:
+        return {
+            'id': self.id,
+            'name': self.name
+        }
+
+    def deserialize(self, **kwargs) -> None:
+        for k, v in kwargs.items():
+            setattr(self, k, v)

--- a/tests/test_base_model.py
+++ b/tests/test_base_model.py
@@ -63,6 +63,5 @@ class TestBaseModel(unittest.TestCase):
         """
         Test base model id get/set
         """
-        self.assertEqual(self.base.id, 1)
         self.base.id = 2
         self.assertEqual(self.base.id, 2)

--- a/tests/test_base_model.py
+++ b/tests/test_base_model.py
@@ -29,6 +29,12 @@ class TestBaseModel(unittest.TestCase):
         del self.base
         logging.disable(logging.NOTSET)
 
+    def test_hash(self):
+        """
+        Test hashing
+        """
+        self.assertNotEqual(self.base.__hash__(), self.comparator.__hash__())
+
     def test_typehash(self):
         """
         Test type hashing

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""
+SSM Unittests
+=============
+Modified: 2022-04
+"""
+
+import unittest
+import logging
+import asyncio
+from unittest.mock import AsyncMock
+from myosin.state.ssm import SSM
+from tests.resources.models import TestState
+
+
+class TestSSM(unittest.TestCase):
+
+    def setUp(self) -> None:
+        logging.disable()
+        self.test_state = TestState(1)
+        self.ssm = SSM[TestState](self.test_state)
+
+    def tearDown(self) -> None:
+        del self.ssm
+        logging.disable(logging.NOTSET)
+
+    def test_reference_hash(self):
+        """
+        Test for correct reference hash return
+        """
+        print(hash(self.ssm.ref))
+        self.assertEqual(self.ssm.refhash, hash(self.test_state))
+
+    def test_type_hash(self):
+        """
+        Test for correct type hash return
+        """
+        self.assertEqual(self.ssm.typehash, self.test_state.__typehash__())
+
+    def test_ref(self):
+        """
+        Test reference object get/set
+        """
+        new_state = TestState(2)
+        self.ssm.ref = new_state
+        self.assertEqual(self.ssm.ref, new_state)
+
+    def test_queue(self):
+        """
+        Test async queue callback get/set
+        """
+        async def async_callback(_: TestState): ...
+        new_queue = [async_callback]
+        self.ssm.queue = new_queue
+        self.assertEqual(self.ssm.queue, new_queue)
+
+    def test_execute(self):
+        """
+        Test execution runner and exception reporting
+        """
+        alpha_cb = AsyncMock()
+        alpha_cb.side_effect = BaseException
+        beta_cb = AsyncMock()
+        self.ssm.queue = [alpha_cb, beta_cb]
+        asyncio.run(self.ssm.execute())
+        alpha_cb.assert_called_once()
+        beta_cb.assert_called_once()

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -10,15 +10,15 @@ import logging
 import asyncio
 from unittest.mock import AsyncMock
 from myosin.state.ssm import SSM
-from tests.resources.models import TestState
+from tests.resources.models import DemoState
 
 
 class TestSSM(unittest.TestCase):
 
     def setUp(self) -> None:
         logging.disable()
-        self.test_state = TestState(1)
-        self.ssm = SSM[TestState](self.test_state)
+        self.test_state = DemoState(1)
+        self.ssm = SSM[DemoState](self.test_state)
 
     def tearDown(self) -> None:
         del self.ssm
@@ -41,7 +41,7 @@ class TestSSM(unittest.TestCase):
         """
         Test reference object get/set
         """
-        new_state = TestState(2)
+        new_state = DemoState(2)
         self.ssm.ref = new_state
         self.assertEqual(self.ssm.ref, new_state)
 
@@ -49,7 +49,7 @@ class TestSSM(unittest.TestCase):
         """
         Test async queue callback get/set
         """
-        async def async_callback(_: TestState): ...
+        async def async_callback(_: DemoState): ...
         new_queue = [async_callback]
         self.ssm.queue = new_queue
         self.assertEqual(self.ssm.queue, new_queue)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""
+State Unittests
+===============
+Modified: 2022-04
+
+"""
+
+import unittest
+import logging
+
+from tests.resources.models import DemoState
+
+from myosin import State
+from myosin.state.ssm import SSM
+from myosin.exceptions.state import NullCheckoutError, UninitializedStateError
+
+
+class TestState(unittest.TestCase):
+
+    def setUp(self) -> None:
+        logging.disable()
+        self.test_state = DemoState(1)
+        with State() as state:
+            self.state = state
+
+    def tearDown(self) -> None:
+        logging.disable(logging.NOTSET)
+        self.state.reset()
+
+    def test_uninitialized_load(self):
+        """
+        Test loading an uninitalized model
+        """
+        with self.assertRaises(UninitializedStateError):
+            self.state.load(self.test_state)
+
+    def test_load(self):
+        """
+        Test state load keyset and SSM wrapper configuration
+        """
+        # initialize model
+        self.test_state.name = "test"
+        self.state.load(self.test_state)
+        # im setting the test like this in order to test both the keyset and the object set,
+        # I want to raise test assertion failures rather than key errors.
+        ssm = self.state._ssm.get(self.test_state.__typehash__())
+        self.assertIsNotNone(ssm)
+        if ssm is not None:
+            self.assertEqual(ssm.ref, self.test_state)
+
+    def test_null_checkout(self):
+        """
+        Test null checkout fails with NullCheckoutError
+        """
+        with self.assertRaises(NullCheckoutError):
+            _ = self.state.checkout(DemoState)
+
+    def test_checkout(self):
+        """
+        Test checkout copy
+        """
+        # avoid testing loading directly
+        self.state._ssm[self.test_state.__typehash__()] = SSM[DemoState](self.test_state)
+        test_state = self.state.checkout(DemoState)
+        self.assertNotEqual(hash(test_state), hash(self.test_state))


### PR DESCRIPTION
# Description
This feature implements a state subscription listener engine for all registered state models. Other modules can register callback functions tied to any state commit. The syntax for registering state subscription callbacks is:
```python
class Consumer:
    def __init__(self) -> None:
        self.username = ""
        with State() as state:
            state.subscribe(User, self.update)

    async def update(self, usr: User) -> None:
        self.username = usr.name
...
class Producer:

    def fetch_name(self) -> None:
        name = requests.get()
        with State() as state:
           usr = state.checkout(User)
           usr.name = name
           state.commit(usr)
```

## Issues:
closes #12 

## Resolutions
 - [x] Implemented asynchronous state subscriptions
 - [x] State model hashing bug fixes
 - [x] Unittests for state subscription handlers

