### PR TITLE
Optional Model IDs

### DIFF
--- a/myosin/__init__.py
+++ b/myosin/__init__.py
@@ -9,17 +9,15 @@ Lightweight & threadsafe state engine
 
 import logging
 
+from myosin.state import State
 from myosin.__version__ import __version__
-from myosin.typing import _PKey
 from myosin.models.base import BaseModel
 from myosin.models.state import StateModel
-from myosin.state import State
 
 __all__ = [
     '__version__',
     'BaseModel',
     'StateModel',
-    '_PKey',
     'State'
 ]
 

--- a/myosin/__version__.py
+++ b/myosin/__version__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 __all__ = ['__version__']
 
-VERSION = (0, 1, 0)
+VERSION = (0, 1, 1)
 __version__ = '.'.join(map(str, VERSION))

--- a/myosin/models/base.py
+++ b/myosin/models/base.py
@@ -6,7 +6,8 @@ Modified: 2022-03
 """
 
 import logging
-from typing import Any, Dict
+import uuid
+from typing import Any, Dict, Optional
 from abc import ABC, abstractmethod
 
 from myosin.typing import _PKey
@@ -15,8 +16,10 @@ from myosin.utils.funcs import pformat
 
 class BaseModel(ABC):
 
-    def __init__(self, _id: _PKey) -> None:
+    def __init__(self, _id: Optional[_PKey] = None) -> None:
         self._logger = logging.getLogger(__name__)
+        if not _id:
+            _id = str(uuid.uuid4())
         self.id = _id
 
     def __typehash__(self) -> int:
@@ -26,12 +29,13 @@ class BaseModel(ABC):
         return super().__hash__()
 
     def __eq__(self, o: object) -> bool:
+        # NOTE: chance of collision if auto id is used (uuid4)
         if hasattr(o, 'id') and hasattr(self, 'id'):
             return o.id == self.id  # type: ignore
         return False
 
     def __repr__(self) -> str:
-        return "{}".format(pformat(self.serialize()))
+        return pformat(self.serialize())
 
     @property
     def id(self) -> _PKey:
@@ -48,7 +52,7 @@ class BaseModel(ABC):
         """
         Set state model id
 
-        :param _id: state model id 
+        :param _id: state model id
         :type _id: _PKey
         """
         self.__id = _id

--- a/myosin/models/state.py
+++ b/myosin/models/state.py
@@ -13,7 +13,7 @@ Dependencies:
 import os
 import json
 from json import JSONDecodeError
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from myosin.exceptions.cache import CachePathError, NullCachePathError
 from myosin.typing import _PKey
@@ -24,7 +24,7 @@ BP_ENV_VAR = "MYOSIN_CACHE_BASE_PATH"
 
 class StateModel(BaseModel):
 
-    def __init__(self, _id: _PKey) -> None:
+    def __init__(self, _id: Optional[_PKey] = None) -> None:
         super().__init__(_id)
         self.cache_base_path = os.environ.get(BP_ENV_VAR)
         self._cpath = f'{self.cache_base_path}/{self.__class__.__name__}.json'

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,9 +33,13 @@ cover-package       =   myosin
 [coverage:run]
 source              =   myosin
 omit                = 
-    __pycache__/* 
-    tests/* # unittest files
-    myosin/__version__.py
+    */__pycache__/* 
+    */tests/*
+    */__init__.py
+    */__version__.py
 
 [coverage:report]
 show_missing        =   1
+omit                = 
+    */__init__.py
+    */__version__.py

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -6,14 +6,13 @@ import time
 from typing import Any, Dict
 from datetime import datetime
 
-from myosin import _PKey
 from myosin import StateModel
 from myosin import State
 
 
 class User(StateModel):
 
-    def __init__(self, _id: _PKey) -> None:
+    def __init__(self, _id: int) -> None:
         super().__init__(_id)
 
     @property
@@ -46,8 +45,8 @@ class User(StateModel):
 
 class Telemetry(StateModel):
 
-    def __init__(self, _id: _PKey) -> None:
-        super().__init__(_id)
+    def __init__(self) -> None:
+        super().__init__()
 
     @property
     def tp(self) -> float:
@@ -97,7 +96,7 @@ if __name__ == "__main__":
 
     u = User(_id=1)
     u.deserialize(**{'name': "chris", 'email': "chris@email.io"})
-    t = Telemetry(_id=1)
+    t = Telemetry()
     t.deserialize(**{'tp': 65.0})
     u.email = "bad"
     _log.info(u)

--- a/tests/test_base_model.py
+++ b/tests/test_base_model.py
@@ -22,8 +22,10 @@ class TestBaseModel(unittest.TestCase):
     )
     def setUp(self) -> None:
         logging.disable()
+        # test set id
         self.base = BaseModel(1)  # type: ignore
-        self.comparator = BaseModel(2)  # type: ignore
+        # test unset id (autogeneration)
+        self.comparator = BaseModel()  # type: ignore
 
     def tearDown(self) -> None:
         del self.base


### PR DESCRIPTION
# Description
Some models do not require a unique identifier (`id` property) from the perspective of a producer, however it is used internally to determine object equality. For example, it would make sense that a telemetry document from a sensor may simply not require a unique identifier:
```json
{
    "temp": 45.0,
    "timestamp": 1650827424.46608
}
```
Originally I had enforced that the producer must generate a unique identifier before committing the model to the system state. However, this breaks encapsulation since the `id` is only used internally by myosin. I have changed the model parameters to optionally allow the producer to set a unique identifier which is useful for REST API models with database transactions. If unset the `BaseModel` will generate a UUID which any module can access through the same `id` property.

## Resolutions
 - [x] Implement automatic id generation for models without a uuid requirement
 - [x] fix coverage ignores globbing
 - [x] Remove type alias export for primary keys

