### PR TITLE
Classifiers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, '3.10']
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, '3.10']
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,8 @@ name: ci
 on:
   push:
     paths-ignore:
-      - "README.md"
+      - "README.rst"
+      - ".readthedocs.yaml"
       - "docs/**"
     branches:
       - master
@@ -13,19 +14,28 @@ on:
       - master
 
 jobs:
-  coverage:
-    name: coverage
-    runs-on: ubuntu-latest
+  unittest:
+    name: unittest and code coverage
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10]
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
-      - name: Check out the codebase.
+      - name: checkout
         uses: actions/checkout@v2
-      - name: Install dependancies
+      - name: set up python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: install dependancies
         run: |
           python3 -m pip install -r tests/requirements.txt
           python3 -m pip install -r requirements.txt
-      - name: Run tests and collect coverage
+      - name: run tests and collect coverage
         run: nosetests 
-      - name: Upload coverage to Codecov
+      - name: upload coverage to codecov
         uses: codecov/codecov-action@v2
   lint:
     name: flake8 lint
@@ -41,16 +51,18 @@ jobs:
         run: python3 -m pip install flake8
       - name: flake8
         run: flake8
-  pip:
+  package:
     name: python package install
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: true
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,29 +14,6 @@ on:
       - master
 
 jobs:
-  unittest:
-    name: unittest and code coverage
-    strategy:
-      fail-fast: true
-      matrix:
-        python-version: [3.8, 3.9]
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-      - name: set up python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: install dependancies
-        run: |
-          python3 -m pip install -r tests/requirements.txt
-          python3 -m pip install -r requirements.txt
-      - name: run tests and collect coverage
-        run: nosetests 
-      - name: upload coverage to codecov
-        uses: codecov/codecov-action@v2
   lint:
     name: flake8 lint
     runs-on: ubuntu-latest
@@ -51,13 +28,33 @@ jobs:
         run: python3 -m pip install flake8
       - name: flake8
         run: flake8
+  unittest:
+    name: unittest and code coverage
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: set up python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: install dependancies
+        run: |
+          python3 -m pip install -r tests/requirements.txt
+          python3 -m pip install -r requirements.txt
+      - name: run tests and collect coverage
+        run: nosetests 
+      - name: upload coverage to codecov
+        uses: codecov/codecov-action@v2
   package:
     name: python package install
+    needs: lint
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.8, 3.9, '3.10']
-        os: [ubuntu-latest, windows-latest]
+        python-version: ['3.8', '3.9', '3.10']
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10']
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -4,7 +4,22 @@ Usage
 System Requirements
 -------------------
 
-Some features of *myosin* are only written for POSIX compliant systems. Cross-platform support for all features is not currently being pursued. *Myosin* is tested against python versions: ``3.7``, ``3.8`` and ``3.9``. *Myosin* will extend support for future python versions.
+*Myosin* is built for use on embedded linux platforms. Some features of *myosin* are only written for POSIX compliant systems. Cross-platform support for all features is not currently being pursued.
+
+Supported Python Versions
+~~~~~~~~~~~~~~~~~~~~~~~~~
+The table below outlines the distributions and test suite support of *myosin* against different python versions: 
+
+====== =========== =============
+Python Distibution Test Suite
+====== =========== =============
+3.8    Supported   Supported
+------ ----------- -------------
+3.9    Supported   Supported
+------ ----------- -------------
+3.10   Supported   Not Supported
+====== =========== =============
+
 
 Installation
 ------------
@@ -128,5 +143,10 @@ Run the tests using the ``nosetests`` utility:
 .. code-block:: console
 
    nosetests
+
+.. warning::
+   The ``nosetests`` utility is no longer maintained and has compatibility issues with Python 3.10 as noted by this `issue thread <https://github.com/nose-devs/nose/issues/1099>`_. Therefore *myosin* unittests will not be executable on Python 3.10.
+
+   I am looking to migrate to pytest and would love contributor support in unittesting.
 
 The test runner will report the executed tests and generate a coverage report. The coverage goal for this library is 95% or greater. If you want to contribute and don't know how, this is a great place to start.

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
         'Operating System :: Unix',
         'Topic :: Software Development :: Object Brokering',
         'Topic :: Software Development :: Embedded Systems',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8'
         'Programming Language :: Python :: 3.9'
         'Programming Language :: Python :: 3.10'

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,10 @@ setup(
         'Operating System :: Unix',
         'Topic :: Software Development :: Object Brokering',
         'Topic :: Software Development :: Embedded Systems',
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8'
+        'Programming Language :: Python :: 3.9'
+        'Programming Language :: Python :: 3.10'
+        'License :: OSI Approved :: MIT License',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ NAME = 'myosin'
 DESCRIPTION = 'Lightweight state management engine for posix compliant systems'
 EMAIL = 'christian@leapsystems.online'
 AUTHOR = 'Christian Sargusingh'
-REQUIRES_PYTHON = '>=3.7.0'
+REQUIRES_PYTHON = '>=3.8.0'
 VERSION = False
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
# Description
Update Trove classifier descriptors and improve CI coverage to include windows and python 3.10.

## Issues:
closes #24 
closes #26 

## Resolutions
 - [x] Add python 3.10 to package and unittest matrix build
 - [x] Update trove classifiers to include supported python versions
 - [x] Update license trove classifier 

