### PR TITLE
Model Mutex

### DIFF
--- a/example/cloud/mqtt.py
+++ b/example/cloud/mqtt.py
@@ -16,7 +16,7 @@ class MQTTHandler:
     def report_loop(self) -> NoReturn:
         while True:
             time.sleep(0.01)
-            with State() as state:
+            with State(Telemetry) as state:
                 telemetry = state.checkout(Telemetry)
             try:
                 self._logger.info(f"Telemetry report: {telemetry}")
@@ -25,12 +25,12 @@ class MQTTHandler:
                     raise ConnectionError
             except ConnectionError as exc:
                 self._logger.exception("Failed to write to stream: %s", exc)
-                with State() as state:
+                with State(System) as state:
                     system = state.checkout(System)
                     system.online = False
                     state.commit(system, cache=True)
             else:
-                with State() as state:
+                with State(System) as state:
                     system = state.checkout(System)
                     system.online = True
                     state.commit(system, cache=True)

--- a/example/sensors/uart.py
+++ b/example/sensors/uart.py
@@ -15,11 +15,8 @@ class UARTInterface:
         while True:
             time.sleep(0.01)
             reading = random.uniform(10.5, 75.5)
-            with State() as state:
+            with State(Telemetry) as state:
                 telemetry = state.checkout(Telemetry)
                 telemetry.tp = reading
                 state.commit(telemetry, cache=True)
-            with State() as state:
-                telemetry = state.checkout(Telemetry)
-            assert(telemetry.tp ==reading)
             self._logger.info("Telemetry report: %s", telemetry)

--- a/myosin/models/state.py
+++ b/myosin/models/state.py
@@ -20,6 +20,9 @@ BP_ENV_VAR = "MYOSIN_CACHE_BASE_PATH"
 
 
 class StateModel(BaseModel):
+    """
+    System state model for categorical and homogenous data access.
+    """
 
     def __init__(self, _id: Optional[_PKey] = None) -> None:
         super().__init__(_id)

--- a/myosin/state/ssm.py
+++ b/myosin/state/ssm.py
@@ -3,6 +3,7 @@
 import logging
 import asyncio
 import traceback
+from threading import Lock
 from typing import Generic, List, Tuple, TypeVar, Callable
 
 from myosin.models.state import StateModel
@@ -17,7 +18,19 @@ class SSM(Generic[_S]):
     def __init__(self, reference: _S) -> None:
         self._logger = logging.getLogger(__name__)
         self.ref = reference
+        self.lock = Lock()
         self.queue = []
+
+    def __str__(self) -> str:
+        return f"{self.ref.__class__.__qualname__}"
+
+    @property
+    def lock(self) -> Lock:
+        return self.__lock
+
+    @lock.setter
+    def lock(self, lock: Lock) -> None:
+        self.__lock = lock
 
     @property
     def refhash(self) -> int:

--- a/myosin/state/state.py
+++ b/myosin/state/state.py
@@ -8,8 +8,7 @@ Modified: 2022-04
 import copy
 import asyncio
 import logging
-from threading import Lock
-from typing import Dict, Type, TypeVar, Callable
+from typing import Dict, List, Type, TypeVar, Callable
 
 from myosin.state.ssm import SSM
 from myosin.typing import AsyncCallback
@@ -22,22 +21,36 @@ _T = TypeVar('_T', bound=StateModel)
 
 
 class State:
+    """
+    State access context manager. Request mutex locks on one or multiple state models by passing
+    the model class in the initializer.
 
-    # storage mechanism is { name: Model }
+    Example
+    ~~~~~~~
+    ```
+    with State(Model) as state:
+        model = state.checkout(Model)
+        ...
+    ```
+    """
+
+    # shared state memory
     _ssm: Dict[int, SSM] = {}
-    state_lock = Lock()
 
-    def __init__(self) -> None:
+    def __init__(self, *args: Type[_T]) -> None:
         self._logger = logging.getLogger(__name__)
+        self.accessors: List[SSM] = [self._ssm[hash(arg)] for arg in args]
 
     def __enter__(self):
-        self.state_lock.acquire()
-        self._logger.debug("Acquired state lock. Lock state: %s", self.state_lock.locked())
+        for accessor in self.accessors:
+            accessor.lock.acquire()
+            self._logger.info("Acquired %s state lock", accessor)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.state_lock.release()
-        self._logger.debug("Released state lock. Lock state: %s", self.state_lock.locked())
+        for accessor in self.accessors:
+            accessor.lock.release()
+            self._logger.info("Released %s state lock", accessor)
 
     def load(self, model: _T) -> _T:
         """
@@ -89,9 +102,9 @@ class State:
         # do not trust any external pass-by-reference objects!
         state = copy.deepcopy(state)
         self._logger.info("Committing state model of type %s with cache mode: %s",
-            type(state), "enabled" if cache else "disabled")
+                          type(state), "enabled" if cache else "disabled")
         # automatic type inference by typehash
-        _type_hash = state.__typehash__() 
+        _type_hash = state.__typehash__()
         self._logger.debug("Computed type hash: %s", _type_hash)
         # verify typehash exists in ssm registry
         if _type_hash not in self._ssm:

--- a/myosin/state/state.py
+++ b/myosin/state/state.py
@@ -25,8 +25,6 @@ class State:
     State access context manager. Request mutex locks on one or multiple state models by passing
     the model class in the initializer. Avoid nested context manager entry.
 
-    Example
-    -------
     .. code-block:: python
 
         with State(Model) as state:

--- a/myosin/state/state.py
+++ b/myosin/state/state.py
@@ -8,7 +8,7 @@ Modified: 2022-04
 import copy
 import asyncio
 import logging
-from typing import Dict, List, Type, TypeVar, Callable
+from typing import Dict, Set, Type, TypeVar, Callable
 
 from myosin.state.ssm import SSM
 from myosin.typing import AsyncCallback
@@ -39,7 +39,8 @@ class State:
 
     def __init__(self, *args: Type[_T]) -> None:
         self._logger = logging.getLogger(__name__)
-        self.accessors: List[SSM] = [self._ssm[hash(arg)] for arg in args]
+        # use set to ensure locking accessors are mutually exclusive
+        self.accessors: Set[SSM] = {self._ssm[hash(arg)] for arg in args}
 
     def __enter__(self):
         for accessor in self.accessors:

--- a/myosin/state/state.py
+++ b/myosin/state/state.py
@@ -26,12 +26,12 @@ class State:
     the model class in the initializer. Avoid nested context manager entry.
 
     Example
-    ~~~~~~~
-    ```
-    with State(Model) as state:
-        model = state.checkout(Model)
-        ...
-    ```
+    -------
+    .. code-block:: python
+
+        with State(Model) as state:
+            model = state.checkout(Model)
+            ...
     """
 
     # shared state memory


### PR DESCRIPTION
# Description
Introduce granular mutex management for each state model. This improves state access performance and reduces the chance of introducing deadlock scenarios.

## Issues:
closes #41 

## Resolutions
 - [x] add state mutex lock per registered state model
 - [x] add variable accessor arguments to context manager to lock selected state model memory
