### PR TITLE
Async Patch

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check out the codebase.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: install dependancies
         run: python3 -m pip install twine
       - name: build package
         run: ./scripts/build.sh -r ${{ github.ref }}
       - name: Publish distribution to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,16 @@
 Changelog
 *********
 
+
+0.2.3
+======
+
+Fixed
+-----
+* Bug in running ``StateModel`` commit callbacks in a thread with an active `asyncio` event loop has been fixed. Callbacks are now scheduled within the active event loop if available, otherwise a new event loop is created to execute the callbacks asynchronously (`#65`_)
+
+.. _#65: https://github.com/ztnel/myosin/pull/65
+
 0.2b2
 ======
 

--- a/example/__main__.py
+++ b/example/__main__.py
@@ -33,7 +33,7 @@ def synchronous(mqtt: MQTTHandler, sensors:UARTInterface):
 async def asynchronous(mqtt:MQTTHandler, sensors:UARTInterface):
     loop = asyncio.get_running_loop()
     tasks = [
-        loop.create_task(mqtt.async_report_loop()),
+        loop.create_task(mqtt.async_loop()),
         loop.create_task(sensors.async_report_loop())
     ]
     await asyncio.gather(*tasks)
@@ -56,3 +56,4 @@ start_http_server(8000)
 mqtt = MQTTHandler()
 sensors = UARTInterface()
 asyncio.run(asynchronous(mqtt, sensors))
+# synchronous(mqtt, sensors)

--- a/myosin/__version__.py
+++ b/myosin/__version__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 __all__ = ['__version__']
 
-VERSION = (0, 2, 2)
+VERSION = (0, 2, 3)
 __version__ = '.'.join(map(str, VERSION))

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -5,9 +5,12 @@ SSM Unittests
 Modified: 2022-04
 """
 
+import asyncio
+from asyncio.events import AbstractEventLoop
 import unittest
 import logging
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+from threading import Lock
 from myosin.state.ssm import SSM
 from tests.resources.models import DemoState
 
@@ -47,6 +50,14 @@ class TestSSM(unittest.TestCase):
         del self.ssm
         logging.disable(logging.NOTSET)
 
+    def test_lock(self):
+        """
+        Test threading lock property get/set
+        """
+        mock_lock = MagicMock(spec=Lock)
+        self.ssm.lock = mock_lock
+        self.assertEqual(self.ssm.lock, mock_lock)
+
     def test_ref_autoset(self):
         """
         Test reference is autoset in ssm init
@@ -81,3 +92,38 @@ class TestSSM(unittest.TestCase):
         new_queue = [async_callback]
         self.ssm.queue = new_queue
         self.assertEqual(self.ssm.queue, new_queue)
+
+    @patch.object(SSM, "cb_runner")
+    @patch.object(SSM, "_get_asyncio_ctx")
+    def test_execute(self, _get_asyncio_ctx: MagicMock, cb_runner: AsyncMock):
+        """
+        Test async execution wrapper
+        """
+        mock_loop = MagicMock(spec=AbstractEventLoop)
+        _get_asyncio_ctx.return_value = mock_loop
+        # test running loop ctx
+        mock_loop.is_running.return_value = True
+        self.ssm.execute()
+        mock_loop.create_task.assert_called_once()
+        mock_loop.run_until_complete.assert_not_called()
+        mock_loop.reset_mock()
+        # test running loop ctx
+        mock_loop.is_running.return_value = False
+        self.ssm.execute()
+        mock_loop.create_task.assert_not_called()
+        self.assertEqual(mock_loop.run_until_complete.call_count, 2)
+        mock_loop.close.assert_called_once()
+
+    @patch.object(asyncio, "new_event_loop")
+    @patch.object(asyncio, "get_running_loop")
+    def test_get_asyncio_ctx(self, get_running_loop: MagicMock, new_event_loop: MagicMock) -> None:
+        """
+        Test asyncio context is able to be fetched
+        """
+        mock_loop = MagicMock()
+        get_running_loop.return_value = mock_loop
+        self.assertEqual(self.ssm._get_asyncio_ctx(), mock_loop)
+        new_event_loop.return_value = mock_loop
+        get_running_loop.side_effect = RuntimeError
+        self.assertEqual(self.ssm._get_asyncio_ctx(), mock_loop)
+        new_event_loop.assert_called_once()


### PR DESCRIPTION
# Description
The previous `asyncio` task scheduling wrapper violated the `asyncio` low level event loop API by attempting to run an event loop which was already active. In order to solve this we first need to check if the current thread has an active event loop. If there is an active event loop we simply schedule the async callbacks in the event loop and return as part of the callback execution. Otherwise, we need to create and manage a new event loop for the callbacks in the queue.

## Issues
closes #64 

## Resolutions
 - [x] Add event loop context profiler to identify if the current thread is using an `asyncio` event loop
 - [x] Add a conditional to schedule the async callbacks as part of the active event loop (if in event loop context) otherwise build a new event loop and schedule the callback tasks until complete then close the loop. 
 - [x] Improve unittest coverage for new async event loop wrapper.
 - [x] Update deploy job dependancies as a result of node 12 deprecation
 - [x] Update CHANGELOG
 - [x] Bump patch version `v0.2.2` -> `v0.2.3`